### PR TITLE
Use sensors' JSON output, fixes incoherent values with lm-sensors 3.6.0

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,8 +17,8 @@ my %prereqs = (
 requires 'Carp'                      => 0,
 requires 'English'                   => 0,
 requires 'Getopt::Long'              => 0,
-requires 'version'                   => 0
-
+requires 'version'                   => 0,
+requires 'JSON::MaybeXS'             => 0,
 );
 
 if( eval { require Monitoring::Plugin } ) {

--- a/check_lm_sensors
+++ b/check_lm_sensors
@@ -25,6 +25,8 @@ use Getopt::Long;
 use Carp;
 use English qw(-no_match_vars);
 
+use JSON::MaybeXS qw(decode_json);
+
 my $plugin_module = load_module( 'Monitoring::Plugin', 'Nagios::Plugin' );
 my $plugin_threshold_module =
   load_module( 'Monitoring::Plugin::Threshold', 'Nagios::Plugin::Threshold' );
@@ -423,36 +425,31 @@ sub parse_sensors {
           or $plugin->nagios_exit( $plugin_module->UNKNOWN,
             "Error while executing $command: $OS_ERROR\n" );
 
-        $command = "$sensors_bin -A | grep \:";
+        $command = "$sensors_bin -Aj";
 
         $pid = open $output, q{-|}, "$command 2>&1"
           or
           $plugin->nagios_exit( $plugin_module->UNKNOWN, "Cannot execute $command: $OS_ERROR" );
 
-        while (<$output>) {
-            chomp;
-
-            if (/(.*):\s+\+?([0-9\-\.]*)\ ?([^\ ]*)\ /mx) {
-
-                my $name  = $1;
-                my $value = $2;
-
-                if ($sanitize) {
-                    $name =~ s/\ //gmx;
+        my $json = decode_json(do { local $/ = undef; scalar <$output>} );
+        foreach my $chip (values(%{$json})) {
+            while (my ($name, $values) = each(%{$chip})) {
+                while (my ($type, $value) = each(%{$values})) {
+                    if ($type =~ /_(input|average)$/) {
+                        if ($sanitize) {
+                            $name =~ s/\ //gmx;
+                        }
+                        if ($rename{$name}) {
+                            $name = $rename{$name};
+                        }
+                        $sensor_values{$name} = $value;
+                        if ($verbosity || $list) {
+                            print "found sensor $name ($value)\n";
+                        }
+                        last;
+                    }
                 }
-
-                if ( $rename{$name} ) {
-                    $name = $rename{$name};
-                }
-
-                $sensor_values{$name} = $value;
-
-                if ( $verbosity || $list ) {
-                    print "found sensor $name ($value)\n";
-                }
-
             }
-
         }
 
         close $output


### PR DESCRIPTION
lm-sensors 3.6.0 introduced unit scaling in
https://github.com/lm-sensors/lm-sensors/commit/1b8b1bce9e53af91b469f5c585e6365dc6f106ed

Because of this, parsing sensors' normal output results in incoherent
values (millivolts are interpreted as volts for instance).

JSON output is available in lm-sensors 3.5.0 and newer, it was added in:
https://github.com/lm-sensors/lm-sensors/commit/1b36ea429930b05e1b3cb77cdbc24cb1ffbcac61